### PR TITLE
feat: soundness of a simple `imp_checker`

### DIFF
--- a/constraints.v
+++ b/constraints.v
@@ -149,21 +149,21 @@ Definition is_sat (cs : constraints) : Prop :=
 
 Definition imp_checker : Type := constraints -> constraint -> bool.
 
-Record imp_checker' : Type :=
+Structure imp_checker' : Type :=
   { checker : constraints -> constraint -> bool
   ; checker_snd : forall (cs: constraints)(c: constraint),
     checker cs c = true -> forall (model : assignment),
     is_model cs model = true -> is_model_c c model = true
   }.
 
-Class CheckerIsSound(checker : imp_checker) :=
+(* Class CheckerIsSound(checker : imp_checker) :=
   { checker_sound : forall (cs: constraints)(c: constraint),
     checker cs c = true -> forall (model : assignment),
     is_model cs model = true -> is_model_c c model = true
   }.
 
-Theorem something_about(checker: imp_checker) {sound : CheckerIsSound checker} : 
-  ...
+Theorem something_about{checker: imp_checker} {sound : CheckerIsSound checker} : 
+  ... *)
 
 
 (* Si un modelo cumple todas las constraints cs y cs -> c por imp_checker, 
@@ -200,6 +200,11 @@ Proof.
   --- apply (IHcs' h model).
   --- discriminate.
 Qed.
+
+Definition imp_checker_1' : imp_checker' :=
+  {| checker := imp_checker_1
+  ; checker_snd := imp_checker_1_snd
+  |}.
 
 End Constraints.
 

--- a/constraints.v
+++ b/constraints.v
@@ -17,10 +17,113 @@ Inductive cliteral : Type :=
   | C_VAR (n : nat)
   | C_VAL (n : nat).
 
+Definition eq_clit (c c': cliteral): bool :=
+  match c, c' with
+  | C_VAR n, C_VAR n' => n =? n'
+  | C_VAL n, C_VAL n' => n =? n'
+  | _, _ => false
+  end.
+
+Search (?n =? ?m = true).
+
+Theorem eq_clit_refl: forall c: cliteral, eq_clit c c = true.
+Proof.
+  intros c.
+  destruct c.
+  - simpl.
+    apply PeanoNat.Nat.eqb_eq.
+    reflexivity.
+  - simpl.
+    apply PeanoNat.Nat.eqb_eq.
+    reflexivity.
+Qed.
+
+Theorem eq_clit_snd: forall c c': cliteral,((eq_clit c c' = true) <-> c = c').
+Proof.
+  intros c c'.
+  split.
+  - intro c_eq_c'.
+    destruct c.
+  -- destruct c'.
+  --- simpl in c_eq_c'.
+      apply PeanoNat.Nat.eqb_eq in c_eq_c'.
+      rewrite c_eq_c'.
+      reflexivity.
+  --- discriminate.
+  -- destruct c'.
+  --- discriminate.
+  --- simpl in c_eq_c'.
+      apply PeanoNat.Nat.eqb_eq in c_eq_c'.
+      rewrite c_eq_c'.
+      reflexivity.
+  - intro c_is_c'.
+    rewrite c_is_c'.
+    apply eq_clit_refl.
+Qed.
+
 Inductive constraint : Type :=
   | C_GT (l r : cliteral)
-  | C_LE (l r : cliteral)
   | C_EQ (l r : cliteral).
+
+Definition eqc (c c': constraint): bool :=
+  match c, c' with
+  | C_GT l r , C_GT l' r' 
+  | C_EQ l r , C_EQ l' r'  => eq_clit l l' && eq_clit r r'
+  | _, _ => false
+  end.
+
+Search (true <> false).
+
+Definition eqc_refl(c: constraint): eqc c c = true.
+Proof.
+  destruct c.
+  - simpl.
+    apply andb_true_intro.
+    split.
+  -- apply eq_clit_refl.
+  -- apply eq_clit_refl.
+  - simpl.
+    apply andb_true_intro.
+    split.
+  -- apply eq_clit_refl.
+  -- apply eq_clit_refl.
+Qed.
+
+Theorem eqc_snd(c c' : constraint): eqc c c' = true <-> c = c'.
+Proof.
+  split.
+  - intro c_eq_c'.
+    destruct c.
+  -- destruct c' as [l' r'|l' r'].
+  --- simpl in c_eq_c'.
+      symmetry in c_eq_c'.
+      apply Bool.andb_true_eq in c_eq_c'.
+      destruct c_eq_c' as [l_eq_l' r_eq_r'].
+      symmetry in l_eq_l'.
+      symmetry in r_eq_r'.
+      apply eq_clit_snd in l_eq_l'.
+      apply eq_clit_snd in r_eq_r'.
+      rewrite l_eq_l'.
+      rewrite r_eq_r'.
+      reflexivity.
+  --- discriminate.
+  -- destruct c' as [l' r'|l' r'].
+  --- discriminate.
+  --- simpl in c_eq_c'.
+      symmetry in c_eq_c'.
+      apply Bool.andb_true_eq in c_eq_c'.
+      destruct c_eq_c' as [l_eq_l' r_eq_r'].
+      symmetry in l_eq_l'.
+      symmetry in r_eq_r'.
+      apply eq_clit_snd in l_eq_l'.
+      apply eq_clit_snd in r_eq_r'.
+      rewrite l_eq_l'.
+      rewrite r_eq_r'.
+      reflexivity.
+  - intros c_is_c'.
+    rewrite c_is_c'.
+    apply eqc_refl.
+Qed.
 
 Definition constraints : Type := list constraint.
 
@@ -44,6 +147,21 @@ Definition imp_checker_snd (chkr : imp_checker) : Prop :=
   forall cs c,
     chkr cs c = true ->
     forall model, is_model cs model = true -> is_model_c c model = true.
+
+Definition imp_checker_1 (cs: constraints) (c: constraint) : bool :=
+  match cs with
+  | [] => false
+  | c'::cs' => if (eqc c' c) then true else false
+  end.
+
+Theorem imp_checker_1_snd : imp_checker_snd imp_checker_1.
+Proof.
+  unfold imp_checker_snd.
+  intros cs c h.
+  induction cs as [|c' cs' IHcs'].
+  - discriminate.
+  - 
+  Admitted.
 
 
 End Constraints.

--- a/constraints.v
+++ b/constraints.v
@@ -11,13 +11,27 @@ Import Program.
 Require Import List.
 Import ListNotations.
 
+
 Module Constraints.
+
+(* Record checkers: Type := { *)
+(*   checker: nat; *)
+(*   snd: nat *)
+(* }. *)
+
+(* Definition asdf: checkers := {| a:= 10 ;  b:= 10|}. *)
+
+(* Definition es_10 := a asdf. *)
+
 (* 
     Literals 
 {{{*)
+(* INFO: STABLE API *)
 Inductive cliteral : Type :=
-  | C_VAR (n : nat)
-  | C_VAL (n : nat).
+  | C_VAR (n : nat) (* x *)
+  | C_VAL (n : nat) (* c *)
+  | C_VAR_DELTA (n delta : nat) (* x + c *)
+.
 
 Print eq.
 Check (eq (C_VAR 10) (C_VAL 10)).
@@ -29,19 +43,17 @@ Definition eq_clit (c c': cliteral): bool :=
   match c, c' with
   | C_VAR n, C_VAR n' => n =? n'
   | C_VAL n, C_VAL n' => n =? n'
+  | C_VAR_DELTA n d, C_VAR_DELTA n' d' => (n =? n') && (d =? d')
   | _, _ => false
   end.
 
 Theorem eq_clit_refl: forall c: cliteral, eq_clit c c = true. 
 Proof. (*{{{*)
   intros c.
-  destruct c.
-  - simpl.
-    apply PeanoNat.Nat.eqb_eq.
-    reflexivity.
-  - simpl.
-    apply PeanoNat.Nat.eqb_eq.
-    reflexivity.
+  destruct c;
+  try apply Bool.andb_true_iff;
+  try split;
+  try apply PeanoNat.Nat.eqb_refl.
 Qed. (*}}}*)
 
 Theorem eq_clit_snd: forall c c': cliteral,((eq_clit c c' = true) <-> c = c').
@@ -50,18 +62,23 @@ Proof. (*{{{*)
   split.
   - intro c_eq_c'.
     destruct c.
-  -- destruct c'.
+  -- destruct c'; try discriminate.
   --- simpl in c_eq_c'.
       apply PeanoNat.Nat.eqb_eq in c_eq_c'.
       rewrite c_eq_c'.
       reflexivity.
-  --- discriminate.
-  -- destruct c'.
-  --- discriminate.
+  -- destruct c'; try discriminate.
   --- simpl in c_eq_c'.
       apply PeanoNat.Nat.eqb_eq in c_eq_c'.
       rewrite c_eq_c'.
       reflexivity.
+  -- destruct c'; try discriminate.
+     simpl in c_eq_c'.
+     try apply Bool.andb_true_iff in c_eq_c'.
+     destruct c_eq_c' as [n_eq_n' d_eq_d'].
+      apply PeanoNat.Nat.eqb_eq in n_eq_n'.
+      apply PeanoNat.Nat.eqb_eq in d_eq_d'.
+     rewrite <- n_eq_n'. rewrite <- d_eq_d'. reflexivity.
   - intro c_is_c'.
     rewrite c_is_c'.
     apply eq_clit_refl.
@@ -69,11 +86,12 @@ Qed. (*}}}*)
 
 Theorem eq_clit_comm: forall c c': cliteral, eq_clit c c' = eq_clit c' c. 
 Proof. (* {{{ *)
-  intros [n | n] [n' | n'].
-  - simpl. apply PeanoNat.Nat.eqb_sym.
-  - simpl. reflexivity.
-  - simpl. reflexivity.
-  - simpl. apply PeanoNat.Nat.eqb_sym.
+  intros [n | n | n d] [n' | n' | n' d'];
+      try apply PeanoNat.Nat.eqb_sym || reflexivity.
+  - simpl.
+    rewrite (PeanoNat.Nat.eqb_sym n n').
+    rewrite (PeanoNat.Nat.eqb_sym d d').
+    reflexivity.
 Qed. (* }}} *)
 (* }}} Literals *)
 
@@ -138,12 +156,13 @@ Qed. (* }}} *)
 Notation conjunction := (list constraint).
 Notation disjuntion := (list conjunction).
 Definition constraints : Type := disjuntion.
+(** A [constraints] is a disjunctive normal form representation of hypothesis. *)
+
 (*}}} Constraints *)
 
 (*
   Satisfiability of constaints
 {{{*)
-(** A [constraints] is a disjunctive normal form representation of hypothesis. *)
 
 Definition assignment : Type := nat -> EVMWord.
 (** Maps variable indexes to concrete values *)
@@ -153,8 +172,10 @@ Definition cliteral_to_nat (model: assignment) (c: cliteral): nat :=
   match c with
   | C_VAL n => n
   | C_VAR i => wordToNat (model i)
+  | C_VAR_DELTA i delta => wordToNat (model i) + delta
   end.
 
+(* INFO: STABLE API *)
 Definition satisfies_single_constraint (model: assignment) (c: constraint) : bool :=
   let get_value := cliteral_to_nat model in 
   match c with
@@ -180,40 +201,42 @@ Definition is_sat (cs : constraints) : Prop :=
   Implication checkers
 {{{ *)
 
-Definition imp_checker : Type := constraints -> constraint -> bool.
-(** An implication checker is a function which takes some hypothesis constraints and
-    a thesis constraint, and checks whether the hypothesis implies the thesis. 
-    Also refered to as "full implication checker" *)
+Definition imp_checker_fun':= constraints -> constraint -> bool.
 
-Definition imp_checker_snd (chkr : imp_checker) : Prop :=
-  (** Si un modelo cumple todas las constraints cs y cs -> c por imp_checker,
-      entonces en particular el modelo cumple c *)
-  forall cs c,
-    chkr cs c = true ->
-    forall model, is_model cs model = true -> satisfies_single_constraint model c = true.
+Definition imp_checker_snd' (checker: imp_checker_fun') :=
+  forall (cs: constraints) (c: constraint),
+      checker cs c = true -> forall (model: assignment),
+      is_model cs model = true -> satisfies_single_constraint model c = true.
 
-Definition conj_imp_checker : Type := conjunction -> constraint -> bool.
-(** A conjunctive implication checker is a function which takes a conjunction of hypothesis
-   constraints and checks whether it can derive a thesis constraint. *)
+Record imp_checker: Type := 
+  { imp_checker_fun: imp_checker_fun'
+  ; imp_checker_snd: imp_checker_snd' imp_checker_fun
+  }.
 
-Definition conj_imp_checker_snd (chkr : conj_imp_checker) : Prop :=
-  forall cs c,
-    chkr cs c = true ->
-    forall model,
+Definition conj_imp_checker_fun': Type := conjunction -> constraint -> bool.
+Definition conj_imp_checker_snd'(checker: conj_imp_checker_fun'): Type := 
+  forall (cs: conjunction) (c: constraint),
+    checker cs c = true -> forall (model: assignment),
     satisfies_conjunction model cs = true -> satisfies_single_constraint model c = true.
 
-Definition mk_imp_checker (chkr: conj_imp_checker): imp_checker :=
+Record conj_imp_checker: Type := 
+  { conj_imp_checker_fun: conj_imp_checker_fun'
+  ; conj_imp_checker_snd: conj_imp_checker_snd' conj_imp_checker_fun
+  }.
+
+Definition mk_imp_checker_fun (checker: conj_imp_checker_fun'): imp_checker_fun' :=
   (** A full implication checker can be made from a conjunctive implication checker by
       checking that all hypothesis conjunctions imply the thesis constraint. *)
   fun cs c => match cs with
               | [] => false
-              | _ => forallb (fun conj => chkr conj c) cs
+              | _ => forallb (fun conj => checker conj c) cs
               end.
 
 Theorem mk_imp_checker_snd(checker: conj_imp_checker) : 
-  conj_imp_checker_snd checker -> imp_checker_snd (mk_imp_checker checker).
+   imp_checker_snd' (mk_imp_checker_fun checker.(conj_imp_checker_fun)).
 Proof. (*{{{*)
-  intros checker_snd cs c full_checker__cs_imp_c model.
+  destruct checker as [checker checker_snd].
+  intros cs c full_checker__cs_imp_c model.
   induction cs as [|c' cs' IHcs'].
   - discriminate.
   - simpl.
@@ -224,7 +247,7 @@ Proof. (*{{{*)
        rewrite Bool.andb_true_r.
 
        exact (checker_snd c' c checker__c'_imp_c  model).
-    -- unfold mk_imp_checker in  IHcs'.
+    -- unfold mk_imp_checker_fun in  IHcs'.
        pose proof (IHcs' checker__cs'_imp_c) as IHcs'.
        unfold conj_imp_checker_snd in checker_snd.
        pose proof (checker_snd c' c checker__c'_imp_c model) as H.
@@ -232,17 +255,21 @@ Proof. (*{{{*)
        apply Bool.andb_true_iff in model_sat_c'__and__model_sat_cs' as [model_sat_c' model_sat_cs'].
        exact (H model_sat_c').
 Qed. (* }}} *)
+
+Definition mk_imp_checker (checker: conj_imp_checker): imp_checker :=
+  {| imp_checker_fun := mk_imp_checker_fun checker.(conj_imp_checker_fun)
+   ; imp_checker_snd := mk_imp_checker_snd checker
+  |}.
+
 (* }}} Implication checkers *)
 
 (*
   Inclusion implication checker
 {{{ *)
-Definition inclusion_conj_imp_checker (cs: conjunction) (c: constraint) : bool :=
+Definition inclusion_conj_imp_checker_fun (cs: conjunction) (c: constraint) : bool :=
   existsb (eqc c) cs.
 
-Definition inclusion_imp_checker := mk_imp_checker inclusion_conj_imp_checker.
-
-Theorem inclusion_conj_imp_checker_snd: conj_imp_checker_snd inclusion_conj_imp_checker.
+Theorem inclusion_conj_imp_checker_snd: conj_imp_checker_snd' inclusion_conj_imp_checker_fun.
 Proof. (* {{{ *)
   unfold imp_checker_snd.
   intros cs c h.
@@ -268,12 +295,16 @@ Proof. (* {{{ *)
        --- discriminate.
 Qed. (* }}} *)
 
-Theorem inclusion_imp_checker_snd : imp_checker_snd inclusion_imp_checker.
-Proof. (* {{{ *)
-  exact (mk_imp_checker_snd inclusion_conj_imp_checker inclusion_conj_imp_checker_snd).
-Qed. (* }}} *)
+Definition inclusion_conj_imp_checker := 
+  {| conj_imp_checker_fun := inclusion_conj_imp_checker_fun 
+   ; conj_imp_checker_snd := inclusion_conj_imp_checker_snd
+  |}.
+
+Definition inclusion_imp_checker := mk_imp_checker inclusion_conj_imp_checker.
 
 (* }}} *)
+
+
 End Constraints.
 
 (* vim: set foldmethod=marker: *)

--- a/constraints.v
+++ b/constraints.v
@@ -13,9 +13,18 @@ Import ListNotations.
 
 Module Constraints.
 
+(* 
+    Literals 
+{{{*)
 Inductive cliteral : Type :=
   | C_VAR (n : nat)
   | C_VAL (n : nat).
+
+Print eq.
+Check (eq (C_VAR 10) (C_VAL 10)).
+
+Example sanity_check : forall (x: cliteral), x = x.
+Proof. intros c. reflexivity. Qed.
 
 Definition eq_clit (c c': cliteral): bool :=
   match c, c' with
@@ -24,8 +33,8 @@ Definition eq_clit (c c': cliteral): bool :=
   | _, _ => false
   end.
 
-Theorem eq_clit_refl: forall c: cliteral, eq_clit c c = true.
-Proof.
+Theorem eq_clit_refl: forall c: cliteral, eq_clit c c = true. 
+Proof. (*{{{*)
   intros c.
   destruct c.
   - simpl.
@@ -34,10 +43,10 @@ Proof.
   - simpl.
     apply PeanoNat.Nat.eqb_eq.
     reflexivity.
-Qed.
+Qed. (*}}}*)
 
 Theorem eq_clit_snd: forall c c': cliteral,((eq_clit c c' = true) <-> c = c').
-Proof.
+Proof. (*{{{*)
   intros c c'.
   split.
   - intro c_eq_c'.
@@ -57,11 +66,27 @@ Proof.
   - intro c_is_c'.
     rewrite c_is_c'.
     apply eq_clit_refl.
-Qed.
+Qed. (*}}}*)
 
+Theorem eq_clit_comm: forall c c': cliteral, eq_clit c c' = eq_clit c' c. 
+Proof. (* {{{ *)
+  intros [n | n] [n' | n'].
+  - simpl. apply PeanoNat.Nat.eqb_sym.
+  - simpl. reflexivity.
+  - simpl. reflexivity.
+  - simpl. apply PeanoNat.Nat.eqb_sym.
+Qed. (* }}} *)
+(* }}} Literals *)
+
+(* 
+    Constraints 
+{{{ *) 
 Inductive constraint : Type :=
   | C_LT (l r : cliteral)
-  | C_EQ (l r : cliteral).
+  | C_EQ (l r : cliteral)
+  (* | C_EQ_offset(l r : cliteral) (n: nat) *)
+.
+
 
 Definition eqc (c c': constraint): bool :=
   match c, c' with
@@ -70,8 +95,8 @@ Definition eqc (c c': constraint): bool :=
   | _, _ => false
   end.
 
-Definition eqc_refl(c: constraint): eqc c c = true.
-Proof.
+Theorem eqc_refl(c: constraint): eqc c c = true.
+Proof. (* {{{ *)
   destruct c.
   - simpl.
     apply andb_true_intro.
@@ -83,10 +108,10 @@ Proof.
     split.
   -- apply eq_clit_refl.
   -- apply eq_clit_refl.
-Qed.
+Qed. (* }}} *)
 
 Theorem eqc_snd(c c' : constraint): eqc c c' = true <-> c = c'.
-Proof.
+Proof. (* {{{ *)
   split.
   - intro c_eq_c'.
     destruct c.
@@ -119,68 +144,131 @@ Proof.
   - intros c_is_c'.
     rewrite c_is_c'.
     apply eqc_refl.
-Qed.
+Qed. (* }}} *)
 
-Definition constraints : Type := list constraint.
+Theorem eqc_comm: forall c c', eqc c c' = eqc c' c.
+Proof. (* {{{ *)
+  intros [l r | l r] [l' r' | l' r'].
+  - simpl. 
+    rewrite (eq_clit_comm l l').
+    rewrite (eq_clit_comm r r').
+    reflexivity.
+  - simpl. reflexivity.
+  - simpl. reflexivity.
+  - simpl. 
+    rewrite (eq_clit_comm l l').
+    rewrite (eq_clit_comm r r').
+    reflexivity.
+Qed. (* }}} *)
+
+Notation conjunction := (list constraint).
+Notation disjuntion := (list conjunction).
+Definition constraints : Type := disjuntion.
+(*}}} Constraints *)
+
+(*
+  Satisfiability of constaints
+{{{*)
+(** A [constraints] is a disjunctive normal form representation of hypothesis. *)
 
 Definition assignment : Type := nat -> EVMWord.
+(** Maps variable indexes to concrete values *)
 
 Definition cliteral_to_nat (model: assignment) (c: cliteral): nat :=
+  (** The value of the literal [c] under the assigment [model]. *)
   match c with
   | C_VAL n => n
   | C_VAR i => wordToNat (model i)
   end.
 
-Definition is_model_c (c : constraint) (model : assignment) : bool :=
+Definition satisfies_single_constraint (model: assignment) (c: constraint) : bool :=
   let get_value := cliteral_to_nat model in 
   match c with
   | C_EQ l r => get_value l =? get_value r
   | C_LT l r => get_value l <? get_value r
   end.
 
-Fixpoint is_model (cs : constraints) (model : assignment) : bool :=
-  match cs with
-  | [] => true
-  | c::cs' => if (is_model_c c model) then is_model cs' model else false
-  end.
+Definition satisfies_conjunction (model: assignment) (conj: conjunction): bool :=
+  forallb (satisfies_single_constraint model) conj.
+
+Definition satisfies_constraints (model: assignment) (cs: constraints): bool :=
+  forallb (satisfies_conjunction model) cs.
+
+Definition is_model (cs : constraints) (model : assignment) : bool := satisfies_constraints model cs.
+(** A model of some constraints is a model which satisfies the constraints *)
 
 Definition is_sat (cs : constraints) : Prop :=
   exists (model : assignment), is_model cs model = true.
+(* }}} *)
+
+(*
+  Implication checkers
+{{{ *)
 
 Definition imp_checker : Type := constraints -> constraint -> bool.
+(** An implication checker is a function which takes some hypothesis constraints and
+    a thesis constraint, and checks whether the hypothesis implies the thesis. 
+    Also refered to as "full implication checker" *)
 
-Structure imp_checker' : Type :=
-  { checker : constraints -> constraint -> bool
-  ; checker_snd : forall (cs: constraints)(c: constraint),
-    checker cs c = true -> forall (model : assignment),
-    is_model cs model = true -> is_model_c c model = true
-  }.
-
-(* Class CheckerIsSound(checker : imp_checker) :=
-  { checker_sound : forall (cs: constraints)(c: constraint),
-    checker cs c = true -> forall (model : assignment),
-    is_model cs model = true -> is_model_c c model = true
-  }.
-
-Theorem something_about{checker: imp_checker} {sound : CheckerIsSound checker} : 
-  ... *)
-
-
-(* Si un modelo cumple todas las constraints cs y cs -> c por imp_checker, 
-entonces en particular el modelo cumple c*)
 Definition imp_checker_snd (chkr : imp_checker) : Prop :=
+  (** Si un modelo cumple todas las constraints cs y cs -> c por imp_checker,
+      entonces en particular el modelo cumple c *)
   forall cs c,
     chkr cs c = true ->
-    forall model, is_model cs model = true -> is_model_c c model = true.
+    forall model, is_model cs model = true -> satisfies_single_constraint model c = true.
 
-Fixpoint imp_checker_1 (cs: constraints) (c: constraint) : bool :=
-  match cs with
-  | [] => false
-  | c'::cs' => if (eqc c' c) then true else imp_checker_1 cs' c
-  end.
+Definition conj_imp_checker : Type := conjunction -> constraint -> bool.
+(** A conjunctive implication checker is a function which takes a conjunction of hypothesis
+   constraints and checks whether it can derive a thesis constraint. *)
 
-Theorem imp_checker_1_snd : imp_checker_snd imp_checker_1.
-Proof.
+Definition conj_imp_checker_snd (chkr : conj_imp_checker) : Prop :=
+  forall cs c,
+    chkr cs c = true ->
+    forall model,
+    satisfies_conjunction model cs = true -> satisfies_single_constraint model c = true.
+
+Definition mk_imp_checker (chkr: conj_imp_checker): imp_checker :=
+  (** A full implication checker can be made from a conjunctive implication checker by
+      checking that all hypothesis conjunctions imply the thesis constraint. *)
+  fun cs c => match cs with
+              | [] => false
+              | _ => forallb (fun conj => chkr conj c) cs
+              end.
+
+Theorem mk_imp_checker_snd(checker: conj_imp_checker) : 
+  conj_imp_checker_snd checker -> imp_checker_snd (mk_imp_checker checker).
+Proof. (*{{{*)
+  intros checker_snd cs c full_checker__cs_imp_c model.
+  induction cs as [|c' cs' IHcs'].
+  - discriminate.
+  - simpl.
+    simpl in full_checker__cs_imp_c.
+    apply Bool.andb_true_iff in full_checker__cs_imp_c as [checker__c'_imp_c checker__cs'_imp_c].
+    destruct cs' as [|c'' cs''] eqn:E.
+    -- simpl.
+       rewrite Bool.andb_true_r.
+
+       exact (checker_snd c' c checker__c'_imp_c  model).
+    -- unfold mk_imp_checker in  IHcs'.
+       pose proof (IHcs' checker__cs'_imp_c) as IHcs'.
+       unfold conj_imp_checker_snd in checker_snd.
+       pose proof (checker_snd c' c checker__c'_imp_c model) as H.
+       intros model_sat_c'__and__model_sat_cs'.
+       apply Bool.andb_true_iff in model_sat_c'__and__model_sat_cs' as [model_sat_c' model_sat_cs'].
+       exact (H model_sat_c').
+Qed. (* }}} *)
+(* }}} Implication checkers *)
+
+(*
+  Inclusion implication checker
+{{{ *)
+Definition inclusion_conj_imp_checker (cs: conjunction) (c: constraint) : bool :=
+  existsb (eqc c) cs.
+
+Definition inclusion_imp_checker := mk_imp_checker inclusion_conj_imp_checker.
+
+Theorem inclusion_conj_imp_checker_snd: conj_imp_checker_snd inclusion_conj_imp_checker.
+Proof. (* {{{ *)
   unfold imp_checker_snd.
   intros cs c h.
   induction cs as [|c' cs' IHcs'].
@@ -188,23 +276,28 @@ Proof.
   - intros model.
     simpl in h.
     destruct (eqc c' c) eqn:c'_is_c.
-  -- apply eqc_snd in c'_is_c.
-    simpl.
-    destruct (is_model_c c' model) eqn:c'_sat_model.
-  --- intros cs'_sat_model.
-      rewrite c'_is_c in c'_sat_model.
-      exact c'_sat_model.
-  --- discriminate.
-  -- simpl.
-    destruct (is_model_c c' model) eqn:c'_sat_model.
-  --- apply (IHcs' h model).
-  --- discriminate.
-Qed.
+    -- apply eqc_snd in c'_is_c.
+       simpl.
+       destruct (satisfies_single_constraint model c') eqn:c'_sat_model.
+       --- intros cs'_sat_model.
+           rewrite c'_is_c in c'_sat_model.
+           exact c'_sat_model.
+       --- discriminate.
+    -- simpl.
+       destruct (satisfies_single_constraint model c') eqn:c'_sat_model.
+       --- simpl.
+           rewrite (eqc_comm c' c) in c'_is_c.
+           rewrite c'_is_c in h.
+           simpl in h.
+           exact (IHcs' h model).
+       --- discriminate.
+Qed. (* }}} *)
 
-Definition imp_checker_1' : imp_checker' :=
-  {| checker := imp_checker_1
-  ; checker_snd := imp_checker_1_snd
-  |}.
+Theorem inclusion_imp_checker_snd : imp_checker_snd inclusion_imp_checker.
+Proof. (* {{{ *)
+  exact (mk_imp_checker_snd inclusion_conj_imp_checker inclusion_conj_imp_checker_snd).
+Qed. (* }}} *)
 
 End Constraints.
 
+(* vim: set foldmethod=marker: *)

--- a/constraints.v
+++ b/constraints.v
@@ -156,6 +156,16 @@ Record imp_checker' : Type :=
     is_model cs model = true -> is_model_c c model = true
   }.
 
+Class CheckerIsSound(checker : imp_checker) :=
+  { checker_sound : forall (cs: constraints)(c: constraint),
+    checker cs c = true -> forall (model : assignment),
+    is_model cs model = true -> is_model_c c model = true
+  }.
+
+Theorem something_about(checker: imp_checker) {sound : CheckerIsSound checker} : 
+  ...
+
+
 (* Si un modelo cumple todas las constraints cs y cs -> c por imp_checker, 
 entonces en particular el modelo cumple c*)
 Definition imp_checker_snd (chkr : imp_checker) : Prop :=

--- a/constraints.v
+++ b/constraints.v
@@ -24,8 +24,6 @@ Definition eq_clit (c c': cliteral): bool :=
   | _, _ => false
   end.
 
-Search (?n =? ?m = true).
-
 Theorem eq_clit_refl: forall c: cliteral, eq_clit c c = true.
 Proof.
   intros c.
@@ -62,17 +60,15 @@ Proof.
 Qed.
 
 Inductive constraint : Type :=
-  | C_GT (l r : cliteral)
+  | C_LT (l r : cliteral)
   | C_EQ (l r : cliteral).
 
 Definition eqc (c c': constraint): bool :=
   match c, c' with
-  | C_GT l r , C_GT l' r' 
+  | C_LT l r , C_LT l' r' 
   | C_EQ l r , C_EQ l' r'  => eq_clit l l' && eq_clit r r'
   | _, _ => false
   end.
-
-Search (true <> false).
 
 Definition eqc_refl(c: constraint): eqc c c = true.
 Proof.
@@ -129,8 +125,18 @@ Definition constraints : Type := list constraint.
 
 Definition assignment : Type := nat -> EVMWord.
 
+Definition cliteral_to_nat (model: assignment) (c: cliteral): nat :=
+  match c with
+  | C_VAL n => n
+  | C_VAR i => wordToNat (model i)
+  end.
+
 Definition is_model_c (c : constraint) (model : assignment) : bool :=
-  true.
+  let get_value := cliteral_to_nat model in 
+  match c with
+  | C_EQ l r => get_value l =? get_value r
+  | C_LT l r => get_value l <? get_value r
+  end.
 
 Fixpoint is_model (cs : constraints) (model : assignment) : bool :=
   match cs with
@@ -160,7 +166,12 @@ Proof.
   intros cs c h.
   induction cs as [|c' cs' IHcs'].
   - discriminate.
-  - 
+  - intros model.
+    simpl in h.
+    destruct (eqc c' c) eqn:E.
+  -- apply eqc_snd in E.
+      simpl.
+
   Admitted.
 
 

--- a/constraints.v
+++ b/constraints.v
@@ -149,6 +149,13 @@ Definition is_sat (cs : constraints) : Prop :=
 
 Definition imp_checker : Type := constraints -> constraint -> bool.
 
+Record imp_checker' : Type :=
+  { checker : constraints -> constraint -> bool
+  ; checker_snd : forall (cs: constraints)(c: constraint),
+    checker cs c = true -> forall (model : assignment),
+    is_model cs model = true -> is_model_c c model = true
+  }.
+
 (* Si un modelo cumple todas las constraints cs y cs -> c por imp_checker, 
 entonces en particular el modelo cumple c*)
 Definition imp_checker_snd (chkr : imp_checker) : Prop :=

--- a/constraints.v
+++ b/constraints.v
@@ -149,15 +149,17 @@ Definition is_sat (cs : constraints) : Prop :=
 
 Definition imp_checker : Type := constraints -> constraint -> bool.
 
+(* Si un modelo cumple todas las constraints cs y cs -> c por imp_checker, 
+entonces en particular el modelo cumple c*)
 Definition imp_checker_snd (chkr : imp_checker) : Prop :=
   forall cs c,
     chkr cs c = true ->
     forall model, is_model cs model = true -> is_model_c c model = true.
 
-Definition imp_checker_1 (cs: constraints) (c: constraint) : bool :=
+Fixpoint imp_checker_1 (cs: constraints) (c: constraint) : bool :=
   match cs with
   | [] => false
-  | c'::cs' => if (eqc c' c) then true else false
+  | c'::cs' => if (eqc c' c) then true else imp_checker_1 cs' c
   end.
 
 Theorem imp_checker_1_snd : imp_checker_snd imp_checker_1.
@@ -168,12 +170,19 @@ Proof.
   - discriminate.
   - intros model.
     simpl in h.
-    destruct (eqc c' c) eqn:E.
-  -- apply eqc_snd in E.
-      simpl.
-
-  Admitted.
-
+    destruct (eqc c' c) eqn:c'_is_c.
+  -- apply eqc_snd in c'_is_c.
+    simpl.
+    destruct (is_model_c c' model) eqn:c'_sat_model.
+  --- intros cs'_sat_model.
+      rewrite c'_is_c in c'_sat_model.
+      exact c'_sat_model.
+  --- discriminate.
+  -- simpl.
+    destruct (is_model_c c' model) eqn:c'_sat_model.
+  --- apply (IHcs' h model).
+  --- discriminate.
+Qed.
 
 End Constraints.
 


### PR DESCRIPTION
Dado un `imp_checker` de semántica, `imp_checker cs c :=  c in cs`, probar que su definición es correcta.